### PR TITLE
SCA: Upgrade convert-source-map component from 2.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5750,7 +5750,7 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "2.0.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the convert-source-map component version 2.0.0. The recommended fix is to upgrade to version .

