### PR TITLE
SCA: Upgrade chownr component from 1.1.4 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5327,7 +5327,7 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
+      "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the chownr component version 1.1.4. The recommended fix is to upgrade to version 3.0.0.

