### PR TITLE
SCA: Upgrade node-glob component from 8.1.0 to 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10388,7 +10388,7 @@
     },
     "node_modules/mocha/node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the node-glob component version 8.1.0. The recommended fix is to upgrade to version 11.0.1.

