### PR TITLE
SCA: Upgrade @types/node component from 20.14.10 to 22.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3653,7 +3653,7 @@
       }
     },
     "node_modules/@wdio/runner/node_modules/@types/node": {
-      "version": "20.14.10",
+      "version": "22.10.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
       "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @types/node component version 20.14.10. The recommended fix is to upgrade to version 22.10.7.

