### PR TITLE
SCA: Upgrade typedarray-to-buffer component from 3.1.5 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14304,7 +14304,7 @@
       }
     },
     "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
+      "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the typedarray-to-buffer component version 3.1.5. The recommended fix is to upgrade to version 4.0.0.

