### PR TITLE
SCA: Upgrade fastq component from 1.17.1 to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7399,7 +7399,7 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
+      "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the fastq component version 1.17.1. The recommended fix is to upgrade to version 1.18.0.

