### PR TITLE
SCA: Upgrade @types/istanbul-lib-report component from 3.0.3 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2886,7 +2886,7 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
+      "version": "",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @types/istanbul-lib-report component version 3.0.3. The recommended fix is to upgrade to version .

