### PR TITLE
SCA: Upgrade saucelabs component from 7.5.0 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3671,7 +3671,7 @@
         "@wdio/types": "8.39.0",
         "@wdio/utils": "8.39.0",
         "ip": "^2.0.1",
-        "saucelabs": "7.5.0",
+        "saucelabs": "8.0.0",
         "webdriverio": "8.39.1"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the saucelabs component version 7.5.0. The recommended fix is to upgrade to version 8.0.0.

