### PR TITLE
SCA: Upgrade ky component from 0.33.3 to 1.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9667,7 +9667,7 @@
       }
     },
     "node_modules/ky": {
-      "version": "0.33.3",
+      "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
       "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the ky component version 0.33.3. The recommended fix is to upgrade to version 1.7.4.

