### PR TITLE
SCA: Upgrade mimic-fn component from 4.0.0 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11056,7 +11056,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "dependencies": {
-        "mimic-fn": "^4.0.0"
+        "mimic-fn": "^5.0.0"
       },
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the mimic-fn component version 4.0.0. The recommended fix is to upgrade to version 5.0.0.

