### PR TITLE
SCA: Upgrade @types/resolve component from 1.20.2 to 1.20.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2948,7 +2948,7 @@
       "dev": true
     },
     "node_modules/@types/resolve": {
-      "version": "1.20.2",
+      "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @types/resolve component version 1.20.2. The recommended fix is to upgrade to version 1.20.6.

