### PR TITLE
SCA: Upgrade write-file-atomic component from 3.0.3 to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15261,7 +15261,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the write-file-atomic component version 3.0.3. The recommended fix is to upgrade to version 6.0.0.

