### PR TITLE
SCA: Upgrade read-pkg component from 5.2.0 to 9.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12079,7 +12079,7 @@
       "dev": true,
       "dependencies": {
         "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
+        "read-pkg": "^9.0.1",
         "type-fest": "^0.8.1"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the read-pkg component version 5.2.0. The recommended fix is to upgrade to version 9.0.1.

