### PR TITLE
SCA: Upgrade @nodelib/fs.stat component from 2.0.5 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,7 +2286,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-4.0.0.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @nodelib/fs.stat component version 2.0.5. The recommended fix is to upgrade to version 4.0.0.

