### PR TITLE
SCA: Upgrade Acorn component from 8.12.1 to 8.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3974,7 +3974,7 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
+      "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Acorn component version 8.12.1. The recommended fix is to upgrade to version 8.14.0.

