### PR TITLE
SCA: Upgrade node-mkdirp component from 1.0.4 to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13826,7 +13826,7 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
       "bin": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the node-mkdirp component version 1.0.4. The recommended fix is to upgrade to version 3.0.1.

