### PR TITLE
SCA: Upgrade @babel/plugin-transform-block-scoping component from 7.24.7 to 7.25.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -883,7 +883,7 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
       "integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-transform-block-scoping component version 7.24.7. The recommended fix is to upgrade to version 7.25.9.

