### PR TITLE
SCA: Upgrade bytes.js component from 3.1.2 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,7 +4928,7 @@
       "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the bytes.js component version 3.1.2. The recommended fix is to upgrade to version .

