### PR TITLE
SCA: Upgrade get-intrinsic component from 1.2.4 to 1.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7966,7 +7966,7 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
+      "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the get-intrinsic component version 1.2.4. The recommended fix is to upgrade to version 1.2.7.

