### PR TITLE
SCA: Upgrade aproba component from 2.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4163,7 +4163,7 @@
       }
     },
     "node_modules/aproba": {
-      "version": "2.0.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the aproba component version 2.0.0. The recommended fix is to upgrade to version .

