### PR TITLE
SCA: Upgrade @rollup/plugin-commonjs component from 26.0.1 to 28.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2519,7 +2519,7 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "26.0.1",
+      "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.1.tgz",
       "integrity": "sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @rollup/plugin-commonjs component version 26.0.1. The recommended fix is to upgrade to version 28.0.2.

