### PR TITLE
SCA: Upgrade yazl component from 2.5.1 to 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15416,7 +15416,7 @@
       }
     },
     "node_modules/yazl": {
-      "version": "2.5.1",
+      "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
       "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the yazl component version 2.5.1. The recommended fix is to upgrade to version 3.3.1.

