### PR TITLE
SCA: Upgrade minimist-options component from 4.1.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10242,7 +10242,7 @@
       }
     },
     "node_modules/minimist-options": {
-      "version": "4.1.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the minimist-options component version 4.1.0. The recommended fix is to upgrade to version .

