### PR TITLE
SCA: Upgrade fill-range component from 7.1.1 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4977,7 +4977,7 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "fill-range": "^"
       },
       "engines": {
         "node": ">=8"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the fill-range component version 7.1.1. The recommended fix is to upgrade to version .

