### PR TITLE
SCA: Upgrade jshttp/mime-types component from 2.1.35 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10174,7 +10174,7 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
+      "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the jshttp/mime-types component version 2.1.35. The recommended fix is to upgrade to version 3.0.0.

