### PR TITLE
SCA: Upgrade node-ignore component from 5.3.1 to 7.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8526,7 +8526,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
       "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the node-ignore component version 5.3.1. The recommended fix is to upgrade to version 7.0.3.

