### PR TITLE
SCA: Upgrade setImmediate component from 1.0.5 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12941,7 +12941,7 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true
     },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the setImmediate component version 1.0.5. The recommended fix is to upgrade to version .

