### PR TITLE
SCA: Upgrade @webassemblyjs/floating-point-hex-parser component from 1.11.6 to 1.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3775,7 +3775,7 @@
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
+      "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
       "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @webassemblyjs/floating-point-hex-parser component version 1.11.6. The recommended fix is to upgrade to version 1.14.1.

