### PR TITLE
SCA: Upgrade string-width component from 5.1.2 to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,7 +1923,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the string-width component version 5.1.2. The recommended fix is to upgrade to version 7.2.0.

