### PR TITLE
SCA: Upgrade jsbn component from 1.1.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8717,7 +8717,7 @@
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
       "dependencies": {
-        "jsbn": "1.1.0",
+        "jsbn": "",
         "sprintf-js": "^1.1.3"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the jsbn component version 1.1.0. The recommended fix is to upgrade to version .

