### PR TITLE
SCA: Upgrade minimatch component from 9.0.5 to 10.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14986,7 +14986,7 @@
     },
     "node_modules/webdriverio/node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the minimatch component version 9.0.5. The recommended fix is to upgrade to version 10.0.1.

