### PR TITLE
SCA: Upgrade babel-plugin-polyfill-regenerator component from 0.6.2 to 0.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4718,7 +4718,7 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
       "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the babel-plugin-polyfill-regenerator component version 0.6.2. The recommended fix is to upgrade to version 0.6.3.

