### PR TITLE
SCA: Upgrade constant-case component from 3.0.4 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5284,7 +5284,7 @@
       "dependencies": {
         "camel-case": "^4.1.2",
         "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
+        "constant-case": "^4.0.0",
         "dot-case": "^3.0.4",
         "header-case": "^2.0.4",
         "no-case": "^3.0.4",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the constant-case component version 3.0.4. The recommended fix is to upgrade to version 4.0.0.

