### PR TITLE
SCA: Upgrade sindresorhus/supports-color component from 5.5.0 to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5265,7 +5265,7 @@
       }
     },
     "node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
+      "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the sindresorhus/supports-color component version 5.5.0. The recommended fix is to upgrade to version 10.0.0.

