### PR TITLE
SCA: Upgrade @babel/plugin-transform-optional-chaining component from 7.24.7 to 7.25.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -545,7 +545,7 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.7"
+        "@babel/plugin-transform-optional-chaining": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-transform-optional-chaining component version 7.24.7. The recommended fix is to upgrade to version 7.25.9.

