### PR TITLE
SCA: Upgrade minipass component from 5.0.0 to 7.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13727,7 +13727,7 @@
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.2",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the minipass component version 5.0.0. The recommended fix is to upgrade to version 7.1.2.

