### PR TITLE
SCA: Upgrade resq component from 1.11.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12455,7 +12455,7 @@
       }
     },
     "node_modules/resq": {
-      "version": "1.11.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
       "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the resq component version 1.11.0. The recommended fix is to upgrade to version .

