### PR TITLE
SCA: Upgrade Inquirer.js component from 9.2.12 to 12.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8597,7 +8597,7 @@
       "dev": true
     },
     "node_modules/inquirer": {
-      "version": "9.2.12",
+      "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
       "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Inquirer.js component version 9.2.12. The recommended fix is to upgrade to version 12.3.2.

