### PR TITLE
SCA: Upgrade is-glob component from 4.0.3 to 

### DIFF
--- a/docs/engine.io-protocol/v3-test-suite/package-lock.json
+++ b/docs/engine.io-protocol/v3-test-suite/package-lock.json
@@ -573,7 +573,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the is-glob component version 4.0.3. The recommended fix is to upgrade to version .

