### PR TITLE
SCA: Upgrade base64-arraybuffer component from 0.1.4 to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13170,7 +13170,7 @@
     },
     "node_modules/socket.io-client-v2/node_modules/base64-arraybuffer": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the base64-arraybuffer component version 0.1.4. The recommended fix is to upgrade to version 1.0.2.

