### PR TITLE
SCA: Upgrade base64-arraybuffer component from 1.0.2 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4788,7 +4788,7 @@
       }
     },
     "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
+      "version": "",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the base64-arraybuffer component version 1.0.2. The recommended fix is to upgrade to version .

