### PR TITLE
SCA: Upgrade socks-proxy-agent component from 8.0.4 to 8.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11231,7 +11231,7 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.5",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the socks-proxy-agent component version 8.0.4. The recommended fix is to upgrade to version 8.0.5.

