### PR TITLE
SCA: Upgrade package-hash component from 4.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11251,7 +11251,7 @@
       }
     },
     "node_modules/package-hash": {
-      "version": "4.0.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
       "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the package-hash component version 4.0.0. The recommended fix is to upgrade to version .

