### PR TITLE
SCA: Upgrade read-pkg-up component from 7.0.1 to 11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10085,7 +10085,7 @@
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
         "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
+        "read-pkg-up": "^11.0.0",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
         "type-fest": "^0.18.0",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the read-pkg-up component version 7.0.1. The recommended fix is to upgrade to version 11.0.0.

