### PR TITLE
SCA: Upgrade babel-traverse component from 7.24.7 to 7.26.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -305,7 +305,7 @@
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
+        "@babel/traverse": "^7.26.5",
         "@babel/types": "^7.24.7"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the babel-traverse component version 7.24.7. The recommended fix is to upgrade to version 7.26.5.

