### PR TITLE
SCA: Upgrade redent component from 3.0.0 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12271,7 +12271,7 @@
       }
     },
     "node_modules/redent": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the redent component version 3.0.0. The recommended fix is to upgrade to version 4.0.0.

