### PR TITLE
SCA: Upgrade @tsconfig/node16 component from 1.0.4 to 16.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2798,7 +2798,7 @@
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @tsconfig/node16 component version 1.0.4. The recommended fix is to upgrade to version 16.1.3.

