### PR TITLE
SCA: Upgrade data-uri-to-buffer component from 4.0.1 to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5934,7 +5934,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the data-uri-to-buffer component version 4.0.1. The recommended fix is to upgrade to version 6.0.2.

