### PR TITLE
SCA: Upgrade node-releases component from 2.0.14 to 2.0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10609,7 +10609,7 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
+      "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the node-releases component version 2.0.14. The recommended fix is to upgrade to version 2.0.19.

