### PR TITLE
SCA: Upgrade jshttp/content-type component from 1.0.5 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5742,7 +5742,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the jshttp/content-type component version 1.0.5. The recommended fix is to upgrade to version .

