### PR TITLE
SCA: Upgrade @types/mocha component from 10.0.7 to 10.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2926,7 +2926,7 @@
     },
     "node_modules/@types/mocha": {
       "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
       "dev": true
     },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @types/mocha component version 10.0.7. The recommended fix is to upgrade to version 10.0.10.

