### PR TITLE
SCA: Upgrade node-glob component from 10.4.5 to 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,7 +2570,7 @@
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
       "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the node-glob component version 10.4.5. The recommended fix is to upgrade to version 11.0.1.

