### PR TITLE
SCA: Upgrade mime component from 1.6.0 to 4.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12823,7 +12823,7 @@
         "etag": "~1.8.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "mime": "1.6.0",
+        "mime": "4.0.6",
         "ms": "2.1.3",
         "on-finished": "2.4.1",
         "range-parser": "~1.2.1",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the mime component version 1.6.0. The recommended fix is to upgrade to version 4.0.6.

