### PR TITLE
SCA: Upgrade supertest component from 7.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "socket.io-client-v2": "npm:socket.io-client@^2.5.0",
         "socket.io-msgpack-parser": "^3.0.2",
         "superagent": "^9.0.2",
-        "supertest": "^7.0.0",
+        "supertest": "^",
         "text-blob-builder": "^0.0.1",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the supertest component version 7.0.0. The recommended fix is to upgrade to version .

