### PR TITLE
SCA: Upgrade has-binary2 component from 1.0.3 to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8231,7 +8231,7 @@
       }
     },
     "node_modules/has-binary2": {
-      "version": "1.0.3",
+      "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the has-binary2 component version 1.0.3. The recommended fix is to upgrade to version 2.0.0.

