### PR TITLE
SCA: Upgrade delegates component from 1.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,7 +4432,7 @@
       "deprecated": "This package is no longer supported.",
       "dev": true,
       "dependencies": {
-        "delegates": "^1.0.0",
+        "delegates": "^",
         "readable-stream": "^3.6.0"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the delegates component version 1.0.0. The recommended fix is to upgrade to version .

