### PR TITLE
SCA: Upgrade clean-stack component from 2.2.0 to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,7 +5405,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the clean-stack component version 2.2.0. The recommended fix is to upgrade to version 5.2.0.

