### PR TITLE
SCA: Upgrade is-fullwidth-code-point component from 3.0.0 to 5.0.0

### DIFF
--- a/docs/engine.io-protocol/v3-test-suite/package-lock.json
+++ b/docs/engine.io-protocol/v3-test-suite/package-lock.json
@@ -946,7 +946,7 @@
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
+        "is-fullwidth-code-point": "^5.0.0",
         "strip-ansi": "^6.0.1"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the is-fullwidth-code-point component version 3.0.0. The recommended fix is to upgrade to version 5.0.0.

