### PR TITLE
SCA: Upgrade uid-safe component from 2.1.5 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14351,7 +14351,7 @@
       }
     },
     "node_modules/uid-safe": {
-      "version": "2.1.5",
+      "version": "",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the uid-safe component version 2.1.5. The recommended fix is to upgrade to version .

