### PR TITLE
SCA: Upgrade @jridgewell/trace-mapping component from 0.3.25 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,7 +2242,7 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
+      "version": "",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @jridgewell/trace-mapping component version 0.3.25. The recommended fix is to upgrade to version .

