### PR TITLE
SCA: Upgrade isarray component from 1.0.0 to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8958,7 +8958,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the isarray component version 1.0.0. The recommended fix is to upgrade to version 2.0.5.

