### PR TITLE
SCA: Upgrade es6-error component from 4.1.1 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,7 +6882,7 @@
       "peer": true
     },
     "node_modules/es6-error": {
-      "version": "4.1.1",
+      "version": "",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the es6-error component version 4.1.1. The recommended fix is to upgrade to version .

