### PR TITLE
SCA: Upgrade ansi-regex component from 5.0.1 to 6.1.0

### DIFF
--- a/docs/engine.io-protocol/v3-test-suite/package-lock.json
+++ b/docs/engine.io-protocol/v3-test-suite/package-lock.json
@@ -1166,7 +1166,7 @@
     },
     "ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the ansi-regex component version 5.0.1. The recommended fix is to upgrade to version 6.1.0.

