### PR TITLE
SCA: Upgrade napi-build-utils component from 1.0.2 to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10475,7 +10475,7 @@
       }
     },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
+      "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the napi-build-utils component version 1.0.2. The recommended fix is to upgrade to version 2.0.0.

