### PR TITLE
SCA: Upgrade @babel/plugin-transform-object-rest-spread component from 7.24.7 to 7.25.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,7 +1665,7 @@
         "@babel/plugin-transform-new-target": "^7.24.7",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
         "@babel/plugin-transform-numeric-separator": "^7.24.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.25.9",
         "@babel/plugin-transform-object-super": "^7.24.7",
         "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
         "@babel/plugin-transform-optional-chaining": "^7.24.7",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-transform-object-rest-spread component version 7.24.7. The recommended fix is to upgrade to version 7.25.9.

