### PR TITLE
SCA: Upgrade escape-string-regexp component from 1.0.5 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5248,7 +5248,7 @@
       "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
+        "escape-string-regexp": "^5.0.0",
         "supports-color": "^5.3.0"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the escape-string-regexp component version 1.0.5. The recommended fix is to upgrade to version 5.0.0.

