### PR TITLE
SCA: Upgrade memory-stream component from 1.0.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10050,7 +10050,7 @@
       }
     },
     "node_modules/memory-stream": {
-      "version": "1.0.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
       "integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the memory-stream component version 1.0.0. The recommended fix is to upgrade to version .

