### PR TITLE
SCA: Upgrade deepmerge component from 4.3.1 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6037,7 +6037,7 @@
       }
     },
     "node_modules/deepmerge": {
-      "version": "4.3.1",
+      "version": "",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the deepmerge component version 4.3.1. The recommended fix is to upgrade to version .

