### PR TITLE
SCA: Upgrade yeast component from 0.1.2 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15425,7 +15425,7 @@
       }
     },
     "node_modules/yeast": {
-      "version": "0.1.2",
+      "version": "",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the yeast component version 0.1.2. The recommended fix is to upgrade to version .

