### PR TITLE
SCA: Upgrade yargs-parser component from 20.2.9 to 21.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10343,7 +10343,7 @@
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
         "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
+        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the yargs-parser component version 20.2.9. The recommended fix is to upgrade to version 21.1.1.

