### PR TITLE
SCA: Upgrade @babel/plugin-syntax-numeric-separator component from 7.10.4 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,7 +1629,7 @@
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-numeric-separator": "^",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-syntax-numeric-separator component version 7.10.4. The recommended fix is to upgrade to version .

