### PR TITLE
SCA: Upgrade buffer-alloc component from 1.2.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5032,7 +5032,7 @@
       }
     },
     "node_modules/buffer-alloc": {
-      "version": "1.2.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the buffer-alloc component version 1.2.0. The recommended fix is to upgrade to version .

