### PR TITLE
SCA: Upgrade asap component from 2.0.6 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4505,7 +4505,7 @@
       }
     },
     "node_modules/asap": {
-      "version": "2.0.6",
+      "version": "",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the asap component version 2.0.6. The recommended fix is to upgrade to version .

