### PR TITLE
SCA: Upgrade loglevel component from 1.9.1 to 1.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9938,7 +9938,7 @@
       }
     },
     "node_modules/loglevel": {
-      "version": "1.9.1",
+      "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
       "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the loglevel component version 1.9.1. The recommended fix is to upgrade to version 1.9.2.

