### PR TITLE
SCA: Upgrade pretty-format component from 29.7.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11613,7 +11613,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the pretty-format component version 29.7.0. The recommended fix is to upgrade to version .

