### PR TITLE
SCA: Upgrade @types/ws component from 8.5.10 to 8.5.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2981,7 +2981,7 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
+      "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @types/ws component version 8.5.10. The recommended fix is to upgrade to version 8.5.13.

