### PR TITLE
SCA: Upgrade estree-walker component from 2.0.2 to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2526,7 +2526,7 @@
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
+        "estree-walker": "^3.0.3",
         "glob": "^10.4.1",
         "is-reference": "1.2.1",
         "magic-string": "^0.30.3"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the estree-walker component version 2.0.2. The recommended fix is to upgrade to version 3.0.3.

