### PR TITLE
SCA: Upgrade webdriverjs component from 8.39.0 to 9.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,7 +3645,7 @@
         "deepmerge-ts": "^5.1.0",
         "expect-webdriverio": "^4.12.0",
         "gaze": "^1.1.3",
-        "webdriver": "8.39.0",
+        "webdriver": "9.5.4",
         "webdriverio": "8.39.1"
       },
       "engines": {


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the webdriverjs component version 8.39.0. The recommended fix is to upgrade to version 9.5.4.

