### PR TITLE
SCA: Upgrade calvinmetcalf/lie component from 3.3.0 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9691,7 +9691,7 @@
       }
     },
     "node_modules/lie": {
-      "version": "3.3.0",
+      "version": "",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the calvinmetcalf/lie component version 3.3.0. The recommended fix is to upgrade to version .

