### PR TITLE
SCA: Upgrade @babel/plugin-transform-typeof-symbol component from 7.24.7 to 7.25.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1679,7 +1679,7 @@
         "@babel/plugin-transform-spread": "^7.24.7",
         "@babel/plugin-transform-sticky-regex": "^7.24.7",
         "@babel/plugin-transform-template-literals": "^7.24.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.24.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.25.9",
         "@babel/plugin-transform-unicode-escapes": "^7.24.7",
         "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-transform-typeof-symbol component version 7.24.7. The recommended fix is to upgrade to version 7.25.9.

