### PR TITLE
SCA: Upgrade camelcase component from 5.3.1 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5190,7 +5190,7 @@
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^5.3.1",
+        "camelcase": "^8.0.0",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
       },


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the camelcase component version 5.3.1. The recommended fix is to upgrade to version 8.0.0.

