### PR TITLE
SCA: Upgrade @babel/plugin-syntax-class-properties component from 7.12.13 to 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,7 +595,7 @@
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
+      "version": "",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the @babel/plugin-syntax-class-properties component version 7.12.13. The recommended fix is to upgrade to version .

