### PR TITLE
SCA: Upgrade Webpack component from 5.92.1 to 5.97.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15006,7 +15006,7 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.92.1",
+      "version": "5.97.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
       "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Webpack component version 5.92.1. The recommended fix is to upgrade to version 5.97.1.

