### PR TITLE
SCA: Upgrade Send for Node.js component from 0.18.0 to 0.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12910,7 +12910,7 @@
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Send for Node.js component version 0.18.0. The recommended fix is to upgrade to version 0.19.1.

