### PR TITLE
SCA: Upgrade Socket.IO Parser component from 3.3.3 to 4.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13237,7 +13237,7 @@
       "dev": true
     },
     "node_modules/socket.io-client-v2/node_modules/socket.io-parser": {
-      "version": "3.3.3",
+      "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.3.tgz",
       "integrity": "sha512-qOg87q1PMWWTeO01768Yh9ogn7chB9zkKtQnya41Y355S0UmpXgpcrFwAgjYJxu9BdKug5r5e9YtVSeWhKBUZg==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the Socket.IO Parser component version 3.3.3. The recommended fix is to upgrade to version 4.2.4.

