### PR TITLE
SCA: Upgrade body-parser component from 1.20.2 to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7216,7 +7216,7 @@
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "2.0.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the body-parser component version 1.20.2. The recommended fix is to upgrade to version 2.0.2.

