### PR TITLE
SCA: Upgrade axios component from 1.7.7 to 1.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4544,7 +4544,7 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.7.7",
+      "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
       "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the axios component version 1.7.7. The recommended fix is to upgrade to version 1.7.9.

