### PR TITLE
SCA: Upgrade expressjs/express component from 4.19.2 to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eiows": "^7.1.0",
         "engine.io-client-v3": "npm:engine.io-client@^3.5.2",
         "expect.js": "^0.3.1",
-        "express": "^4.19.2",
+        "express": "^5.0.1",
         "express-session": "^1.18.0",
         "has-cors": "^1.1.0",
         "helmet": "^7.1.0",


### PR DESCRIPTION
BlackDuck has identified a vulnerability in the expressjs/express component version 4.19.2. The recommended fix is to upgrade to version 5.0.1.

